### PR TITLE
Krylov update

### DIFF
--- a/core/eigensolvers.f
+++ b/core/eigensolvers.f
@@ -399,7 +399,7 @@
 !     ----- Normalization to be unit-norm -----
          alpha_r = real_eigvec%norm() ; alpha_i = imag_eigvec%norm()
          alpha = alpha_r**2 + alpha_i**2 ; beta = 1.0d0/sqrt(alpha)
-         call krylov_cmult(real_eigvec, beta) ; call krylov_cmult(imag_eigvec, beta)
+         real_eigvec = beta*real_eigvec ; imag_eigvec = beta*imag_eigvec
 
 !     ----- Output the real and imaginary parts -----
          call krylov_outpost(real_eigvec, nRe) ; call krylov_outpost(imag_eigvec, nIm)

--- a/core/eigensolvers.f
+++ b/core/eigensolvers.f
@@ -397,7 +397,7 @@
          call krylov_matmul(imag_eigvec, Q(1:k_dim), aimag(vecs(:, i)), k_dim)
 
 !     ----- Normalization to be unit-norm -----
-         call krylov_norm(alpha_r, real_eigvec) ; call krylov_norm(alpha_i, imag_eigvec)
+         alpha_r = krylov_norm(real_eigvec) ; alpha_i = krylov_norm(imag_eigvec)
          alpha = alpha_r**2 + alpha_i**2 ; beta = 1.0d0/sqrt(alpha)
          call krylov_cmult(real_eigvec, beta) ; call krylov_cmult(imag_eigvec, beta)
 
@@ -441,13 +441,13 @@
       if (nid .eq. 0) then
 
          close(10) ; close(20) ;  close(30)
-!     
+!
          write(fmt2,'("(A,I16)")')
          write(fmt3,'("(A,F16.4)")')
          write(fmt4,'("(A,F16.12)")')
          write(fmt5,'("(A,E15.7)")') ! max precision
          write(fmt6,'("(A,E13.4)")') ! same as hmhlz
-!     
+!
          write(filename,'(A,A,A)')'Spectre_',trim(evop),'.info'
 !     write(filename,"(',I7.7,'.info')") itime/ioutput
          open (844,file=filename,action='write',status='replace')
@@ -507,32 +507,32 @@
 
 !     This function selects the eigenvalues to be placed in the upper left corner
 !     during the Schur condensation phase.
-!     
+!
 !     INPUTS
 !     ------
-!     
+!
 !     vals : n-dimensional complex array.
 !     Array containing the eigenvalues.
 
 !     delta : real
 !     All eigenvalues outside the circle of radius 1-delta will be selected.
-!     
+!
 !     nev : integer
 !     Number of desired eigenvalues. At least nev+4 eigenvalues will be selected
 !     to ensure "smooth" convergence of the Krylov-Schur iterations.
-!     
+!
 !     n : integer
 !     Total number of eigenvalues.
-!     
+!
 !     RETURNS
 !     -------
-!     
+!
 !     selected : n-dimensional logical array.
 !     Array indicating which eigenvalue has been selected (.true.).
-!     
+!
 !     cnt : integer
 !     Number of selected eigenvalues. cnt >= nev + 4.
-!     
+!
 !     Last edit : April 2nd 2020 by JC Loiseau.
 
       implicit none
@@ -580,22 +580,22 @@
 
 !     This function implements a fairly simple checkpointing procedure in case one
 !     would need to restart the computation (e.g. in case of cluster shutdown).
-!     
+!
 !     INPUTS
 !     ------
-!     
+!
 !     f_xr, f_yr, f_zr : nek arrays of size lv = lx1*ly1*lz1*lelv
 !     Velocity components of the latest Krylov vector.
-!     
+!
 !     f_pr : nek array of size lp = lx2*ly2*lz2*lelt
 !     Pressure field of the latest Krylov vector.
-!     
+!
 !     H : k+1 x k real matrix.
 !     Current upper Hessenberg matrix resulting from the k-step Arnoldi factorization.
-!     
+!
 !     k : int
 !     Current iteration of the Arnoldi factorization.
-!     
+!
 !     Last edit : April 3rd 2020 by JC Loiseau.
 
       use krylov_subspace

--- a/core/eigensolvers.f
+++ b/core/eigensolvers.f
@@ -397,7 +397,7 @@
          call krylov_matmul(imag_eigvec, Q(1:k_dim), aimag(vecs(:, i)), k_dim)
 
 !     ----- Normalization to be unit-norm -----
-         alpha_r = krylov_norm(real_eigvec) ; alpha_i = krylov_norm(imag_eigvec)
+         alpha_r = real_eigvec%norm() ; alpha_i = imag_eigvec%norm()
          alpha = alpha_r**2 + alpha_i**2 ; beta = 1.0d0/sqrt(alpha)
          call krylov_cmult(real_eigvec, beta) ; call krylov_cmult(imag_eigvec, beta)
 

--- a/core/eigensolvers.f
+++ b/core/eigensolvers.f
@@ -122,7 +122,7 @@
 
          mstart = 1; istep = 1; time = 0.0d0
 
-         call krylov_copy(Q(1), wrk)
+         Q(1) = wrk
 
          call whereyouwant('KRY',1)
          time = 0.0d0
@@ -421,7 +421,7 @@
             if(uparam(1).eq.3.31)uparam(1)=3.11 ! changing to linearized solver in Floquet
             call bcast(uparam(1),wdsize)
 
-            call krylov_copy(opt_prt, real_eigvec)
+            opt_prt = real_eigvec
             call matvec(opt_rsp, opt_prt) ! baseflow already in ubase
             call krylov_outpost(opt_rsp, 'ore')
 

--- a/core/eigensolvers.f
+++ b/core/eigensolvers.f
@@ -37,7 +37,7 @@
       time   = 0.0d0
       H(:,:)  = 0.0d0; b_vec  = 0.0d0 ; residual = 0.0d0
       do i = 1,k_dim+1
-         call krylov_zero(Q(i))
+         call Q(i)%zero()
       enddo
 
 !     ----- Loading baseflow from disk (optional) -----

--- a/core/krylov_decomposition.f
+++ b/core/krylov_decomposition.f
@@ -162,7 +162,7 @@
 !     --> Initialize array.
       call rzero(h_vec, k)
 
-      beta = krylov_norm(f)
+      beta = f%norm()
 
 !     --> Orthonormalize f w.r.t the Krylov basis.
       do i = 1, k

--- a/core/krylov_decomposition.f
+++ b/core/krylov_decomposition.f
@@ -67,7 +67,7 @@
       endif
 
 !     --> Initialize arrays.
-      call krylov_zero(f) ; alpha = 0.0d0
+      call f%zero() ; alpha = 0.0d0
 
 !     --> Arnoldi factorization.
       do mstep = mstart, mend
@@ -166,7 +166,7 @@
 !     --> Orthogonalize f w.r.t. to q_i.
          alpha = krylov_inner_product(f, wrk)
          call krylov_cmult(wrk, alpha)
-         call krylov_sub2(f, wrk)
+         f = f - wrk
 
 !     --> Update the corresponding entry in the Hessenberg matrix.
          H(i, k) = alpha
@@ -177,7 +177,7 @@
          wrk = q(i)
          alpha = krylov_inner_product(f, wrk)
          call krylov_cmult(wrk, alpha)
-         call krylov_sub2(f, wrk)
+         f = f - wrk
          H(i, k) = H(i, k) + alpha
       enddo
 

--- a/core/krylov_decomposition.f
+++ b/core/krylov_decomposition.f
@@ -9,35 +9,35 @@
 !     This function implements the k-step Arnoldi factorization of the linearized
 !     Navier-Stokes operator. The rank k of the Arnoldi factorization is set as a user
 !     parameter in x_SIZE.f (see parameter k_dim).
-!     
+!
 !     INPUT
 !     -----
-!     
+!
 !     mstart : integer
 !     Index at which to start the Arnoldi factorization. By default, it should be set to 1.
 !     Note that it changes when the Arnoldi factorization is used as part of the Krylov-Schur
 !     algorithm.
-!     
+!
 !     mend : integer
 !     Index at which to stop the Arnoldi factorization. By default, it should be set to kdim.
 !     Note that it changes when the Arnoldi factorization is used as part of the GMRES solver
-!     
+!
 !     ksize : integer
 !     Size of the Krylov subspace (same as k_dim).
-!     
+!
 !     RETURNS
 !     -------
-!     
+!
 !     qx, qy, qz : nek arrays of size (lx1*ly1*lz1*lelt, ksize).
 !     Arrays containing the various Krylov vectors associated to each velocity component.
-!     
+!
 !     qp : nek arrays of size (lx2*ly2*lz2*lelt, ksize)
 !     Arrays containing the various Krylov vectors associated to the pressure field.
-!     
+!
 !     H : k x k real matrix.
 !     Upper Hessenberg matrix resulting from the Arnoldi factorization of the linearized
 !     Navier-Stokes operator.
-!     
+!
 !     Last edit : April 3rd 2020 by JC Loiseau.
       use krylov_subspace
       implicit none
@@ -117,30 +117,30 @@
 
 !     This function orthonormalizes the latest Krylov vector f w.r.t. all of the
 !     previous ones and updates the entries of the Hessenberg matrix accordingly.
-!     
+!
 !     INPUTS
 !     ------
-!     
+!
 !     k : int
 !     Current step of the Arnoldi factorization.
-!     
+!
 !     f_xr, f_yr, f_zr : nek arrays of size lt = lx1*ly1*lz1*lelt.
 !     Velocity components of the latest Krylov vector.
 !     When returned, it has been orthonormalized w.r.t. to all previous
 !     Krylov vectors.
-!     
+!
 !     f_pr : nek array of size lp = lx2*ly2*lz2*lelt.
 !     Pressure component of the latest Krylov vector.
-!     
+!
 !     qx, qy, qz : nek arrays of size (lv, k)
 !     Velocity components of the Krylov basis.
-!     
+!
 !     qp : nek array of size (lp, k).
 !     Pressure component of the Krylov basis.
-!     
+!
 !     H : k x k real matrix.
 !     Upper Hessenberg matrix.
-!     
+!
 !     Last edit : April 3rd 2020 by JC Loiseau.
 
       use krylov_subspace
@@ -162,7 +162,7 @@
 !     --> Initialize array.
       call rzero(h_vec, k)
 
-      call krylov_norm(beta, f)
+      beta = krylov_norm(f)
 
 !     --> Orthonormalize f w.r.t the Krylov basis.
       do i = 1, k

--- a/core/krylov_decomposition.f
+++ b/core/krylov_decomposition.f
@@ -171,7 +171,7 @@
          call krylov_copy(wrk, q(i))
 
 !     --> Orthogonalize f w.r.t. to q_i.
-         call krylov_inner_product(alpha, f, wrk)
+         alpha = krylov_inner_product(f, wrk)
          call krylov_cmult(wrk, alpha)
          call krylov_sub2(f, wrk)
 
@@ -183,7 +183,7 @@
 !     --> Perform full re-orthogonalization (see instability of MGS process).
       do i = 1, k
          call krylov_copy(wrk, q(i))
-         call krylov_inner_product(alpha, f, wrk)
+         alpha = krylov_inner_product(f, wrk)
          call krylov_cmult(wrk, alpha)
          call krylov_sub2(f, wrk)
          H(i, k) = H(i, k) + alpha

--- a/core/krylov_decomposition.f
+++ b/core/krylov_decomposition.f
@@ -160,14 +160,9 @@
 
 !     --> Orthonormalize f w.r.t the Krylov basis.
       do i = 1, k
-!     --> Copy the i-th Krylov vector to the working arrays.
-         wrk  = q(i)
-
 !     --> Orthogonalize f w.r.t. to q_i.
-         alpha = krylov_inner_product(f, wrk)
-         call krylov_cmult(wrk, alpha)
-         f = f - wrk
-
+         alpha = krylov_inner_product(f, q(i))
+         f = f - alpha*q(i)
 !     --> Update the corresponding entry in the Hessenberg matrix.
          H(i, k) = alpha
       enddo
@@ -175,9 +170,8 @@
 !     --> Perform full re-orthogonalization (see instability of MGS process).
       do i = 1, k
          wrk = q(i)
-         alpha = krylov_inner_product(f, wrk)
-         call krylov_cmult(wrk, alpha)
-         f = f - wrk
+         alpha = krylov_inner_product(f, q(i))
+         f = f - alpha*q(i)
          H(i, k) = H(i, k) + alpha
       enddo
 

--- a/core/krylov_subspace.f
+++ b/core/krylov_subspace.f
@@ -4,7 +4,7 @@
       include 'TOTAL'
 
       private
-      public krylov_outpost, krylov_inner_product, krylov_norm, krylov_normalize, krylov_cmult, krylov_add2, krylov_sub2, krylov_zero, krylov_copy, krylov_matmul, krylov_biorthogonalize, krylov_gradient
+      public krylov_outpost, krylov_inner_product, krylov_normalize, krylov_cmult, krylov_add2, krylov_sub2, krylov_zero, krylov_copy, krylov_matmul, krylov_biorthogonalize, krylov_gradient
 
       integer, public, parameter :: lv = lx1*ly1*lz1*lelv
       integer, public, parameter :: lp = lx2*ly2*lz2*lelv
@@ -17,7 +17,10 @@
         real :: time
 
       contains
-        procedure :: norm => krylov_norm
+        private
+        ! --> Define the norm of the Krylov vector.
+        procedure, pass(self) :: krylov_norm
+        generic, public    :: norm => krylov_norm
       end type krylov_vector
 
       type(krylov_vector), save, public :: ic_nwt, fc_nwt
@@ -79,10 +82,10 @@
 
 
 
-      real function krylov_norm(p) result(alpha)
+      real function krylov_norm(self) result(alpha)
       implicit none
-      class(krylov_vector), intent(in) :: p
-      alpha = krylov_inner_product(p, p)
+      class(krylov_vector), intent(in) :: self
+      alpha = krylov_inner_product(self, self)
       alpha = dsqrt(alpha)
       return
       end function krylov_norm

--- a/core/krylov_subspace.f
+++ b/core/krylov_subspace.f
@@ -8,7 +8,7 @@
 
       integer, public, parameter :: lv = lx1*ly1*lz1*lelv
       integer, public, parameter :: lp = lx2*ly2*lz2*lelv
-      integer, save, public :: n,n2
+      integer, save, public :: n, n2
 
       type, public :: krylov_vector
       real, dimension(lv) :: vx, vy, vz
@@ -44,10 +44,9 @@
 
 
 
-      subroutine krylov_inner_product(alpha, p, q)
+      real function krylov_inner_product(p, q) result(alpha)
       implicit none
       type(krylov_vector), intent(in) :: p, q
-      real, intent(out) :: alpha
       real :: glsc3
       integer m
 
@@ -71,7 +70,7 @@
       if ( isnan(alpha) ) call nek_end
 
       return
-      end subroutine krylov_inner_product
+      end function krylov_inner_product
 
 
 
@@ -80,7 +79,7 @@
       real function krylov_norm(p) result(alpha)
       implicit none
       type(krylov_vector), intent(in) :: p
-      call krylov_inner_product(alpha, p, p)
+      alpha = krylov_inner_product(p, p)
       alpha = dsqrt(alpha)
       return
       end function krylov_norm
@@ -297,19 +296,19 @@
 
 !     --> Normalize the direct mode to unit-norm.
       alpha = krylov_norm(real_p) ; alpha = alpha**2
-      beta  = krylov_norm(imag_p)  ; beta  = beta**2
+      beta  = krylov_norm(imag_p) ; beta  = beta**2
 
       delta = 1.0D+00 / sqrt(alpha + beta)
       call krylov_cmult(real_p, delta)
       call krylov_cmult(imag_p, delta)
 
 !     --> Inner product between direct and adjoint modes.
-      call krylov_inner_product(alpha, real_p, real_q)
-      call krylov_inner_product(beta, imag_p, imag_q)
+      alpha = krylov_inner_product(real_p, real_q)
+      beta  = krylov_inner_product(imag_p, imag_q)
       gamma = alpha + beta
 
-      call krylov_inner_product(alpha, real_q, imag_p)
-      call krylov_inner_product(beta, imag_q, real_p)
+      alpha = krylov_inner_product(real_q, imag_p)
+      beta  = krylov_inner_product(imag_q, real_p)
       delta = alpha - beta
 
 !     --> Bi-orthogonalize the adjoint mode.

--- a/core/krylov_subspace.f
+++ b/core/krylov_subspace.f
@@ -11,10 +11,13 @@
       integer, save, public :: n, n2
 
       type, public :: krylov_vector
-      real, dimension(lv) :: vx, vy, vz
-      real, dimension(lp) :: pr
-      real, dimension(lv,ldimt) :: theta
-      real :: time
+        real, dimension(lv) :: vx, vy, vz
+        real, dimension(lp) :: pr
+        real, dimension(lv,ldimt) :: theta
+        real :: time
+
+      contains
+        procedure :: norm => krylov_norm
       end type krylov_vector
 
       type(krylov_vector), save, public :: ic_nwt, fc_nwt
@@ -78,7 +81,7 @@
 
       real function krylov_norm(p) result(alpha)
       implicit none
-      type(krylov_vector), intent(in) :: p
+      class(krylov_vector), intent(in) :: p
       alpha = krylov_inner_product(p, p)
       alpha = dsqrt(alpha)
       return
@@ -94,7 +97,7 @@
       real, intent(out) :: alpha
 
 !     --> Compute the user-defined norm.
-      alpha = krylov_norm(p)
+      alpha = p%norm()
 !     --> Normalize the vector.
       call krylov_cmult(p, 1.0D+00/alpha)
 
@@ -297,8 +300,7 @@
       real :: alpha, beta, gamma, delta
 
 !     --> Normalize the direct mode to unit-norm.
-      alpha = krylov_norm(real_p) ; alpha = alpha**2
-      beta  = krylov_norm(imag_p) ; beta  = beta**2
+      alpha = real_p%norm()**2 ; beta  = imag_p%norm()**2
 
       delta = 1.0D+00 / sqrt(alpha + beta)
       call krylov_cmult(real_p, delta)

--- a/core/krylov_subspace.f
+++ b/core/krylov_subspace.f
@@ -108,12 +108,11 @@
       subroutine krylov_cmult(p, alpha)
       implicit none
 
-      type(krylov_vector) :: p
-      real alpha
-      integer i
+      type(krylov_vector), intent(inout) :: p
+      real, intent(in) :: alpha
+      integer :: i
 
-      n = nx1*ny1*nz1*nelv
-      n2 = nx2*ny2*nz2*nelv
+      n = nx1*ny1*nz1*nelv ; n2 = nx2*ny2*nz2*nelv
 
       call cmult(p%vx(:),alpha,n)
       call cmult(p%vy(:),alpha,n)
@@ -136,7 +135,8 @@
       subroutine krylov_add2(p, q)
       implicit none
 
-      type(krylov_vector) :: p, q
+      type(krylov_vector), intent(inout) :: p
+      type(krylov_vector), intent(in)    :: q
       integer i
 
       n = nx1*ny1*nz1*nelv
@@ -163,10 +163,11 @@
       subroutine krylov_sub2(p, q)
       implicit none
 
-      type(krylov_vector) :: p, q
-      integer i
-      n = nx1*ny1*nz1*nelv
-      n2 = nx2*ny2*nz2*nelv
+      type(krylov_vector), intent(inout) :: p
+      type(krylov_vector), intent(in)    :: q
+      integer :: i
+
+      n = nx1*ny1*nz1*nelv ;n2 = nx2*ny2*nz2*nelv
 
       call sub2(p%vx(:),q%vx(:),n)
       call sub2(p%vy(:),q%vy(:),n)
@@ -189,10 +190,10 @@
       subroutine krylov_zero(p)
       implicit none
 
-      type(krylov_vector) :: p
-      integer i
-      n = nx1*ny1*nz1*nelv
-      n2 = nx2*ny2*nz2*nelv
+      type(krylov_vector), intent(inout) :: p
+      integer :: i
+
+      n = nx1*ny1*nz1*nelv ; n2 = nx2*ny2*nz2*nelv
 
       call rzero(p%vx(:),n)
       call rzero(p%vy(:),n)
@@ -215,11 +216,11 @@
       subroutine krylov_copy(p, q)
       implicit none
 
-      type(krylov_vector) :: p, q
-      integer i
+      type(krylov_vector), intent(inout) :: p
+      type(krylov_vector), intent(in)    :: q
+      integer :: i
 
-      n = nx1*ny1*nz1*nelv
-      n2 = nx2*ny2*nz2*nelv
+      n = nx1*ny1*nz1*nelv ; n2 = nx2*ny2*nz2*nelv
 
       call copy(p%vx(:),q%vx(:),n)
       call copy(p%vy(:),q%vy(:),n)
@@ -242,11 +243,12 @@
       subroutine krylov_matmul(dq, Q, yvec, k)
       implicit none
 
-      integer :: i, j, k
-      type(krylov_vector) :: dq
-      type(krylov_vector), dimension(k) :: Q
-      real, dimension(k) :: yvec
+      type(krylov_vector), intent(out) :: dq
+      type(krylov_vector), dimension(k), intent(in) :: Q
+      real, dimension(k), intent(in) :: yvec
+      integer, intent(in) :: k
 
+      integer :: i, j
       real, dimension(lv, k) :: qx, qy, qz
       real, dimension(lp, k) :: qp
       real, dimension(lv, k, ldimt) :: qt

--- a/core/krylov_subspace.f
+++ b/core/krylov_subspace.f
@@ -77,16 +77,13 @@
 
 
 
-      subroutine krylov_norm(alpha, p)
+      real function krylov_norm(p) result(alpha)
       implicit none
       type(krylov_vector), intent(in) :: p
-      real, intent(out) :: alpha
-
       call krylov_inner_product(alpha, p, p)
       alpha = dsqrt(alpha)
       return
-      end subroutine krylov_norm
-
+      end function krylov_norm
 
 
 
@@ -98,7 +95,7 @@
       real, intent(out) :: alpha
 
 !     --> Compute the user-defined norm.
-      call krylov_norm(alpha, p)
+      alpha = krylov_norm(p)
 !     --> Normalize the vector.
       call krylov_cmult(p, 1.0D+00/alpha)
 
@@ -299,8 +296,8 @@
       real :: alpha, beta, gamma, delta
 
 !     --> Normalize the direct mode to unit-norm.
-      call krylov_norm(alpha, real_p) ; alpha = alpha**2
-      call krylov_norm(beta, imag_p)  ; beta  = beta**2
+      alpha = krylov_norm(real_p) ; alpha = alpha**2
+      beta  = krylov_norm(imag_p)  ; beta  = beta**2
 
       delta = 1.0D+00 / sqrt(alpha + beta)
       call krylov_cmult(real_p, delta)

--- a/core/matvec.f
+++ b/core/matvec.f
@@ -65,28 +65,28 @@
 
 !     Dispatch the correct matrix-vector product to the Arnoldi factorization.
 !     All subroutines need to have the same interface.
-!     
+!
 !     NOTE : The baseflow needs to be pass to (ubase, vbase, wbase, tbase)
 !     before this function is called.
-!     
+!
 !     INPUTS
 !     ------
-!     
+!
 !     qx, qy, qz, qt : nek-arrays of size lv
 !     Initial velocity and temperature components.
-!     
+!
 !     qp : nek-array of size lp
 !     Initial pressure component.
-!     
+!
 !     OUTPUTS
 !     -------
-!     
+!
 !     fx, fy, fz, ft : nek-arrays of size lv
 !     Final velocity and temperature components.
-!     
+!
 !     fp : nek-array of size lp
 !     Final pressure component.
-!     
+!
 
       use krylov_subspace
       implicit none
@@ -165,9 +165,9 @@
 !     Integrate forward in time the linearized Navier-Stokes equations.
 !     Denoting by L the Jacobian of the Navier-Stokes equations, the corresponding
 !     matrix vector product is thus
-!     
+!
 !     x(t) = exp(t * L) * x(0)
-!     
+!
 !     where x(0) is the initial condition (qx, qy, qz, qp, qt) and x(t) the final
 !     one (fx, fy, fz, fp, ft).
 
@@ -251,9 +251,9 @@
 !     Integrate forward in time the adjoint Navier-Stokes equations.
 !     Denoting by L adjoint Navier-Stokes operator, the corresponding
 !     matrix vector product is thus
-!     
+!
 !     x(t) = exp(t * L) * x(0)
-!     
+!
 !     where x(0) is the initial condition (qx, qy, qz, qp, qt) and x(t) the final
 !     one (fx, fy, fz, fp, ft).
 
@@ -414,7 +414,7 @@
          call krylov_add2(f, bvec)
 
          call compute_bvec(btvec, ic_nwt)
-         call krylov_inner_product(f%time, btvec, q)
+         f%time = krylov_inner_product(btvec, q)
 
          if(nid .eq. 0) write(6,*)'Newton period correction:',f%time
 

--- a/core/matvec.f
+++ b/core/matvec.f
@@ -368,7 +368,6 @@
 
 !     --> Evaluate (I - exp(t*L)) * q0.
       f = q - f
-      !call krylov_cmult(f, -1.0D+00)
 
       return
       end subroutine ts_force_sensitivity_map
@@ -410,8 +409,7 @@
          call btvec%zero()
 
          call compute_bvec(bvec, fc_nwt)
-         call krylov_cmult(bvec, q%time)
-         f = f + bvec
+         f = f + q%time * bvec
 
          call compute_bvec(btvec, ic_nwt)
          f%time = krylov_inner_product(btvec, q)
@@ -466,7 +464,7 @@
 
 !     --> Approximate the time-derivative.
       bvec = wrk2 - wrk1
-      call krylov_cmult(bvec, 1.0/dt)
+      bvec = (1.0D+00/dt) * bvec
       bvec%time = 0.0D+00
 
 

--- a/core/matvec.f
+++ b/core/matvec.f
@@ -453,7 +453,7 @@
       call nopcopy(vx, vy, vz, pr, t, qbase%vx, qbase%vy, qbase%vz, qbase%pr, qbase%theta)
       param(10) = qbase%time
       call prepare_linearized_solver
-      call krylov_copy(wrk1, qbase)
+      wrk1 = qbase
 
 !     --> Single time-step to approximate the time-derivative.
       time = 0.0D+00
@@ -466,7 +466,7 @@
 
 !     --> Approximate the time-derivative.
       call krylov_sub2(wrk2, wrk1)
-      call krylov_copy(bvec, wrk2)
+      bvec = wrk2
       call krylov_cmult(bvec, 1.0/dt)
       bvec%time = 0.0D+00
 

--- a/core/matvec.f
+++ b/core/matvec.f
@@ -367,8 +367,8 @@
       call adjoint_linearized_map(f, q)
 
 !     --> Evaluate (I - exp(t*L)) * q0.
-      call krylov_sub2(f, q)
-      call krylov_cmult(f, -1.0D+00)
+      f = q - f
+      !call krylov_cmult(f, -1.0D+00)
 
       return
       end subroutine ts_force_sensitivity_map
@@ -398,7 +398,7 @@
       call forward_linearized_map(f, q)
 
 !     --> Evaluate (exp(t*L) - I) * q0.
-      call krylov_sub2(f, q)
+      f = f - q
 
 !     ----------------------------------
 !     -----     NEWTON FOR UPO     -----
@@ -406,12 +406,12 @@
 
       if ( uparam(1) .eq. 2.1 ) then
 
-         call krylov_zero(bvec)
-         call krylov_zero(btvec)
+         call bvec%zero()
+         call btvec%zero()
 
          call compute_bvec(bvec, fc_nwt)
          call krylov_cmult(bvec, q%time)
-         f = f + bvec !call krylov_add2(f, bvec)
+         f = f + bvec
 
          call compute_bvec(btvec, ic_nwt)
          f%time = krylov_inner_product(btvec, q)
@@ -465,8 +465,7 @@
      $     vx,      vy,      vz,      pr,      t(1,1,1,1,1))
 
 !     --> Approximate the time-derivative.
-      call krylov_sub2(wrk2, wrk1)
-      bvec = wrk2
+      bvec = wrk2 - wrk1
       call krylov_cmult(bvec, 1.0/dt)
       bvec%time = 0.0D+00
 

--- a/core/matvec.f
+++ b/core/matvec.f
@@ -411,7 +411,7 @@
 
          call compute_bvec(bvec, fc_nwt)
          call krylov_cmult(bvec, q%time)
-         call krylov_add2(f, bvec)
+         f = f + bvec !call krylov_add2(f, bvec)
 
          call compute_bvec(btvec, ic_nwt)
          f%time = krylov_inner_product(btvec, q)

--- a/core/newton_krylov.f
+++ b/core/newton_krylov.f
@@ -324,9 +324,7 @@
       real :: beta
 
 !     --> Initial Krylov vector.
-      call matvec(f, q)
-      f = f - rhs
-      call krylov_cmult(f, -1.0D+00)
+      call matvec(f, q) ; f = rhs - f
 
 !     --> Normalize the starting vector.
       call krylov_normalize(f, beta) ; q = f

--- a/core/newton_krylov.f
+++ b/core/newton_krylov.f
@@ -96,7 +96,7 @@
       tottime = tottime + nsteps*dt
 
 !     --> Check residual || f(q) ||
-      residual = krylov_norm(f) ; residual = residual ** 2
+      residual = f%norm() ; residual = residual ** 2
 !     write(*, *) "RESIDUAL ", residual
 
       if(nid.eq.0)then

--- a/core/newton_krylov.f
+++ b/core/newton_krylov.f
@@ -245,7 +245,7 @@
       enddo
       H = 0.0D+00 ; yvec = 0.0D+00 ; evec = 0.0D+00
 
-      call krylov_copy(Q(1), rhs)
+      Q(1) = rhs
       call krylov_normalize(Q(1), beta)
 
       calls = 0
@@ -283,7 +283,7 @@
       call krylov_add2(sol, dq)
 
 !     --> Recompute residual for sanity check and initialize new Krylov seed if needed.
-      call krylov_copy(Q(1), sol)
+      Q(1) = sol
       call initialize_gmres_vector(beta, Q(1), rhs)
 
       if(nid.eq.0)then
@@ -328,8 +328,7 @@
       call krylov_cmult(f, -1.0D+00)
 
 !     --> Normalize the starting vector.
-      call krylov_normalize(f, beta)
-      call krylov_copy(q, f)
+      call krylov_normalize(f, beta) ; q = f
 
       return
       end subroutine initialize_gmres_vector
@@ -353,7 +352,7 @@
       type(krylov_vector) :: q
 
 !     --> Copy the initial condition to Nek.
-      call krylov_copy(ic_nwt, q) ! for Newton UPO newton_linearized_map
+      ic_nwt = q ! for Newton UPO newton_linearized_map
       call nopcopy(vx, vy, vz, pr, t, q%vx, q%vy, q%vz, q%pr, q%theta)
 
 !     --> Turn-off the linearized solver.
@@ -373,7 +372,7 @@
 
 !     --> Compute the right hand side of the time-stepper Newton.
       call nopcopy(f%vx, f%vy, f%vz, f%pr, f%theta, vx, vy, vz, pr, t)
-      call krylov_copy(fc_nwt, f) ! for Newton UPO newton_linearized_map
+      fc_nwt = f ! for Newton UPO newton_linearized_map
       call krylov_sub2(f, q)
       f%time = 0.0D+00
 

--- a/core/newton_krylov.f
+++ b/core/newton_krylov.f
@@ -280,7 +280,8 @@
 
 !     --> Update solution.
       call krylov_matmul(dq, Q(1:k), yvec(1:k), k)
-      call krylov_add2(sol, dq)
+      sol = sol + dq
+      !call krylov_add2(sol, dq)
 
 !     --> Recompute residual for sanity check and initialize new Krylov seed if needed.
       Q(1) = sol

--- a/core/newton_krylov.f
+++ b/core/newton_krylov.f
@@ -96,7 +96,7 @@
       tottime = tottime + nsteps*dt
 
 !     --> Check residual || f(q) ||
-      call krylov_norm(residual, f) ; residual = residual ** 2
+      residual = krylov_norm(f) ; residual = residual ** 2
 !     write(*, *) "RESIDUAL ", residual
 
       if(nid.eq.0)then
@@ -176,39 +176,39 @@
 
 !     Implementation of simple time-stepper GMRES to be part of the Newton-Krylov solver
 !     for fixed point computation. The rank of the Krylov subspace is set as the user parameter k_dim.
-!     
+!
 !     INPUT
 !     -----
-!     
+!
 !     rhs_x, rhs_y, rhs_z, rhs_t : nek arrays of size (lv).
 !     Arrays containing the right-hand side of the linear problem to be solved.
-!     
+!
 !     rhs_p : nek array of size (lp)
 !     Array containing the right-hand side of the linear problem to be solved (pressure component).
-!     
+!
 !     maxiter : integer
 !     Maximum number of restarts for the GMRES computation.
-!     
+!
 !     ksize : integer
 !     Dimension of the Krylov subspace.
-!     
+!
 !     RETURNS
 !     -------
-!     
+!
 !     sol_x, sol_y, sol_z, sol_t : nek arrays of size (lv).
 !     Arrays containing the solution of the linear problem.
-!     
+!
 !     sol_p : nek array of size (lp).
 !     Array containing the solution of the linear problem (pressure component).
-!     
+!
 !     calls : total number of calls to the linearized solver.
 !     Integer containing the total sum of nsteps*k necessary to converge the solution.
-!     
+!
 !     NOTE : This is a plain implementation of GMRES following the algorithm given in
 !     Y. Saad. Iterative methods for sparse linear systems. Section 6.5 GMRES, alg. 6.9
-!     
+!
 !     Last Edit : March 26th 2021 by JC Loiseau.
-!     
+!
 
       use krylov_subspace
       implicit none

--- a/core/newton_krylov.f
+++ b/core/newton_krylov.f
@@ -50,7 +50,7 @@
       endif
 
 !     --> Initialize arrays.
-      call krylov_zero(f) ; call krylov_zero(dq)
+      call f%zero() ; call dq%zero()
 
 !     --> Copy initial condition.
       call nopcopy(q%vx, q%vy, q%vz, q%pr, q%theta, vx, vy, vz, pr, t)
@@ -119,7 +119,7 @@
       tottime = tottime + calls*dt
 
 !     --> Update Newton solution.
-      call krylov_sub2(q, dq)
+      q = q - dq
 
 !     --> Deallocate nonlinear solution variable!
       if(ifstorebase.and.(uparam(1).eq.2.1.or.uparam(1).eq.2.2))then
@@ -239,9 +239,9 @@
 !     ----- Allocate arrays -----
       allocate(Q(ksize+1),H(ksize+1, ksize), yvec(ksize), evec(ksize+1))
 
-      call krylov_zero(sol)
+      call sol%zero()
       do i = 1, ksize+1
-         call krylov_zero(Q(i))
+         call Q(i)%zero()
       enddo
       H = 0.0D+00 ; yvec = 0.0D+00 ; evec = 0.0D+00
 
@@ -254,7 +254,7 @@
 !     --> Zero-out stuff.
       H = 0.0D+00 ; yvec = 0.0D+00; evec = 0.0D+00 ; evec(1) = beta
       do j = 2, ksize+1
-         call krylov_zero(Q(j))
+         call Q(j)%zero()
       enddo
 
       arnoldi : do k = 1, k_dim
@@ -325,7 +325,7 @@
 
 !     --> Initial Krylov vector.
       call matvec(f, q)
-      call krylov_sub2(f, rhs)
+      f = f - rhs
       call krylov_cmult(f, -1.0D+00)
 
 !     --> Normalize the starting vector.
@@ -374,7 +374,7 @@
 !     --> Compute the right hand side of the time-stepper Newton.
       call nopcopy(f%vx, f%vy, f%vz, f%pr, f%theta, vx, vy, vz, pr, t)
       fc_nwt = f ! for Newton UPO newton_linearized_map
-      call krylov_sub2(f, q)
+      f = f - q
       f%time = 0.0D+00
 
 !     --> Pass current guess as base flow for the linearized calculation.

--- a/core/postproc.f
+++ b/core/postproc.f
@@ -79,9 +79,9 @@ c---------------------------------------------------------
       end
 c---------------------------------------------------------
       subroutine compute_omega(l2)
-c     
+c
 c     Generate \Omega criterion vortex of
-c     
+c
       implicit none
       include 'SIZE'
       include 'TOTAL'
@@ -148,10 +148,10 @@ c---------------------------------------------------------
       end
 c---------------------------------------------------------
       subroutine compute_q(l2)
-c     
+c
 c     Generate Q criterion vortex of Hunt, Wray & Moin, CTR-S88 1988
 c     positive second invariant of velocity gradient tensor
-c     
+c
       include 'SIZE'
       include 'TOTAL'
 
@@ -177,10 +177,10 @@ c
       end
 c---------------------------------------------------------
       subroutine compute_delta(l2)
-c     
+c
 c     Generate  Discriminant (DELTA) criterion vortex of Chong, Perry & Cantwell, Phys. Fluids 1990
 c     complex eigenvalues of velocity gradient tensor
-c     
+c
       include 'SIZE'
       include 'TOTAL'
 
@@ -212,35 +212,35 @@ c
       end
 c---------------------------------------------------------
       subroutine compute_swirling(l2)
-c     
+c
 c     Generate Swirling Strength criterion vortex of
 c     Zhou, Adrian, Balachandar and Kendall, JFM 1999
-c     
+c
 c     imaginary part of complex eigenvalues of velocity gradient tensor
 c     presented as lambda_ci^2
-c     
+c
 c     for the 3x3 case
 c     |d11, d12, d13|  |du/dx,du/dy,du/dz|
 c     D = [d_ij] = |d21, d22, d23|= |dv/dx,dv/dy,dv/dz|
 c     |d31, d32, d33|  |dw/dx,dw/dy,dw/dz|
-c     
+c
 c     |lambda_r,  0,       0      |
 c     [d_ij]= [vr,vcr,vci]|  0,   lambda_cr, lambda_ci|[vr,vcr,vci]^-1
 c     |  0,  -lambda_ci, lambda_cr|
-c     
+c
 c     λ^3+P*λ^2+Qλ+R=0
-c     
+c
 c     where P = -I_D   = -tr(D)
 c     Q = II_D  =  0.5[P*P - tr(DD)]
 c     R = -III_D = 1/3.[-P+3QP-tr(DDD)]
 c     for the 2x2 case
-c     
+c
 c     λ^2+Qλ+R=0
-c     
+c
 c     where Q = II_D  =  0.5[P*P - tr(DD)]
 c     R = -III_D = 1/3.[-P+3QP-tr(DDD)]
-c     
-c     
+c
+c
       include 'SIZE'
       include 'TOTAL'
       parameter (lxyz=lx1*ly1*lz1)
@@ -347,13 +347,13 @@ c---------------------------------------------------------
       end
 c---------------------------------------------------------
       subroutine compute_firstInv(a, l)
-c     
+c
 c     for the 3x3 case
 c     |d11, d12, d13|
 c     D = [d_ij] = |d21, d22, d23|
 c     |d31, d32, d33|
 c     compute_firstInv returns tr(d_ij)=(d11+d22+d33)
-c     
+c
       include 'SIZE'
       include 'TOTAL'
       parameter(lxyz=lx1*ly1*lz1)
@@ -372,14 +372,14 @@ c
       end
 c-------------------------------------------------------------------
       subroutine compute_secondInv(a, l)
-c     
+c
 c     for the 3x3 case
 c     |d11, d12, d13|
 c     D = [d_ij] = |d21, d22, d23|
 c     |d31, d32, d33|
 c     compute_SecondInv returns
 c     0.5*(tr(d_ij)^2+tr(d_ij*d_ij))=-(d22*d33-d23*d32)-(d11*d22-d12*d21)-(d33*d11-d13*d31)
-c     
+c
       include 'SIZE'
       include 'TOTAL'
       parameter (lxyz=lx1*ly1*lz1)
@@ -403,15 +403,15 @@ c
       end
 c-------------------------------------------------------------------
       subroutine compute_thirdInv(a, l)
-c     
+c
 c     for the 3x3 case
 c     |d11, d12, d13|
 c     D = [d_ij] = |d21, d22, d23|
 c     |d31, d32, d33|
-c     
+c
 c     compute_thirdInv returns det(D)
 c     =-d11*(d23*d32-d22*d33)-d12*(d21*d33-d31*d23)-d13*(d31*d22-d21*d32)
-c     
+c
       include 'SIZE'
       include 'TOTAL'
       parameter (lxyz=lx1*ly1*lz1)
@@ -701,7 +701,7 @@ c----------------------------------------------------------------------
       call nopcopy(imag_eigvec%vx, imag_eigvec%vy, imag_eigvec%vz, imag_eigvec%pr, imag_eigvec%theta, vx, vy, vz, pr, t)
 
 !     --> Normalize eigenmode to unit-norm (Sanity check).
-      call krylov_norm(alpha, real_eigvec) ; call krylov_norm(beta, imag_eigvec)
+      alpha = krylov_norm(real_eigvec) ; beta = krylov_norm(imag_eigvec)
       alpha = 1.D+00 / sqrt(alpha**2 + beta**2)
       call krylov_cmult(real_eigvec, alpha) ; call krylov_cmult(imag_eigvec, alpha)
 

--- a/core/postproc.f
+++ b/core/postproc.f
@@ -701,7 +701,7 @@ c----------------------------------------------------------------------
       call nopcopy(imag_eigvec%vx, imag_eigvec%vy, imag_eigvec%vz, imag_eigvec%pr, imag_eigvec%theta, vx, vy, vz, pr, t)
 
 !     --> Normalize eigenmode to unit-norm (Sanity check).
-      alpha = krylov_norm(real_eigvec) ; beta = krylov_norm(imag_eigvec)
+      alpha = real_eigvec%norm() ; beta = imag_eigvec%norm()
       alpha = 1.D+00 / sqrt(alpha**2 + beta**2)
       call krylov_cmult(real_eigvec, alpha) ; call krylov_cmult(imag_eigvec, alpha)
 

--- a/core/postproc.f
+++ b/core/postproc.f
@@ -703,7 +703,7 @@ c----------------------------------------------------------------------
 !     --> Normalize eigenmode to unit-norm (Sanity check).
       alpha = real_eigvec%norm() ; beta = imag_eigvec%norm()
       alpha = 1.D+00 / sqrt(alpha**2 + beta**2)
-      call krylov_cmult(real_eigvec, alpha) ; call krylov_cmult(imag_eigvec, alpha)
+      real_eigvec = alpha*real_eigvec ; imag_eigvec = alpha*imag_eigvec
 
 !     #####
 !     #####

--- a/core/sensitivity.f
+++ b/core/sensitivity.f
@@ -9,20 +9,20 @@
 !     Provided the direct and adjoint modes have already been computed,
 !     this function computes the wavemaker following the formulation by
 !     Giannetti et al. [1]. Set uparam(01) = 4.1 in the par file to use it.
-!     
+!
 !     OUTPOST
 !     -------
-!     
+!
 !     wm_blah0.f000001 : Nek file. The wavemaker is stored in the array
 !     for the temperature.
-!     
+!
 !     References
 !     ----------
-!     
+!
 !     [1] Giannetti F. & Luchini P.
 !     Structural sensitivity of the first instability of the cylinder wake.
 !     J. Fluid Mech., vol 581., 2007.
-!     
+!
 !     NOTE : This implementation does not apply to cases involving temperature
 !     or any other scalar.
 
@@ -89,13 +89,13 @@
 !     Provided the direct and adjoint modes have been computed,
 !     this function computes the baseflow sensitivity following
 !     the formulation by Marquet et al. [1].
-!     
+!
 !     OUTPOST
 !     -------
-!     
+!
 !     References
 !     ----------
-!     
+!
 !     [1] Marquet O., Sipp D. and Jacquin L.
 !     Sensitivity analysis and passive control of cylinder flow
 !     J. Fluid Mech., vol 615, pp. 221-252, 2008.
@@ -228,15 +228,15 @@
 !     A time-stepper formulation of the problem is used and
 !     the linearized system is solved using GMRES. Set uparam(01) = 4.41
 !     to compute the real part and uparam(01) = 4.42 for the imaginary one.
-!     
+!
 !     OUTPOST
 !     -------
-!     
+!
 !     fsr_blah0.f00001 / fsi_blah0.f00001 : Sensitivity fields.
-!     
+!
 !     References
 !     ----------
-!     
+!
 !     [1] Marquet O., Sipp D. and Jacquin L.
 !     Sensitivity analysis and passive control of cylinder flow
 !     J. Fluid Mech., vol 615, pp. 221-252, 2008.
@@ -275,7 +275,7 @@
       call opcopy(rhs%vx, rhs%vy, rhs%vz, vx, vy, vz)
 
 !     --> Zero-out initial guess.
-      call krylov_zero(sol)
+      call sol%zero()
 
 !     --> Recast rhs into time-stepper/discrete-time framework.
       call initialize_rhs_ts_steady_force_sensitivity(rhs)
@@ -359,16 +359,16 @@ c-----------------------------------------------------------------------
 !     Provided the base flow and the steady force sensitivity have been computed,
 !     this function computes the variations of a leading eigenvalue induced
 !     by a steady pointwise force according to eq. (5.1) by Marquet et al. [1].
-!     
+!
 !     OUTPOST
 !     -------
-!     
+!
 !     dfr_blah0.f00001 : Eigenvalue variations (x_comp -> delta_lambda/alpha)
 !     (y_comp -> delta_omega /alpha).
-!     
+!
 !     References
 !     ----------
-!     
+!
 !     [1] Marquet O., Sipp D. and Jacquin L.
 !     Sensitivity analysis and passive control of cylinder flow
 !     J. Fluid Mech., vol 615, pp. 221-252, 2008.

--- a/core/sensitivity.f
+++ b/core/sensitivity.f
@@ -287,7 +287,7 @@
       call ts_gmres(rhs, sol, 10, k_dim, calls)
 
 !     -->
-      call krylov_cmult(sol, alpha)
+      sol = alpha*sol
 
 !     --> Outpost solution.
       call outpost(sol%vx, sol%vy, sol%vz, sol%pr, sol%theta, prefix)


### PR DESCRIPTION
Updated the `krylov_subspace` module with:
- Operator overload (+, -, *, =)
- Clean-up the call to nek's rzero, copy, cmult, etc.
- Added a number of type-bound procedures (e.g. norm)

This update should pave the way for the extension of the krylov_vector type to handle complex-valued vectors and thus enables the computation of the SVD of the resolvent operator.